### PR TITLE
feat(auth): rebuild SignIn and SignUp views with cinematic dark-mode UI

### DIFF
--- a/src/modules/auth/ui/view/sign-in-view.tsx
+++ b/src/modules/auth/ui/view/sign-in-view.tsx
@@ -55,17 +55,14 @@ export const SignInView = () => {
 
   return (
     <div className="min-h-screen bg-[#050505] flex flex-col items-center justify-center p-6 font-sans text-white relative overflow-hidden">
-      {/* Background Glow - Cinematic Depth */}
       <div className="absolute top-0 left-1/2 -translate-x-1/2 w-full max-w-4xl h-[400px] bg-blue-600/10 blur-[120px] pointer-events-none" />
 
-      {/* Top Left Logo */}
       <div className="absolute top-8 left-8 sm:left-12">
         <Link
           href="/"
           className="transition-transform hover:scale-105 block opacity-80 hover:opacity-100"
         >
           <div className="p-1.5 rounded-md bg-white/5 border border-white/10 backdrop-blur-sm">
-            {/* Note: Added 'invert' assuming your original SVG was black for the white background */}
             <Image
               src="/shipspace.svg"
               alt="ShipSpace"
@@ -77,8 +74,7 @@ export const SignInView = () => {
         </Link>
       </div>
 
-      <div className="w-full max-w-md space-y-8 relative z-10">
-        {/* Brand Header */}
+      <div className="w-full max-w-md space-y-8 relative z-10 my-12">
         <div className="text-center space-y-2">
           <h1 className="text-3xl font-semibold tracking-tight text-white">
             Welcome back to the Space.
@@ -88,12 +84,10 @@ export const SignInView = () => {
           </p>
         </div>
 
-        {/* Login Card */}
         <div className="bg-zinc-900/40 border border-zinc-800/50 p-8 rounded-2xl backdrop-blur-xl shadow-2xl">
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
               <div className="space-y-4">
-                {/* Email Field */}
                 <FormField
                   control={form.control}
                   name="email"
@@ -105,6 +99,8 @@ export const SignInView = () => {
                       <FormControl>
                         <Input
                           {...field}
+                          type="email"
+                          autoComplete="email"
                           className="h-11 bg-zinc-950 border-zinc-800 text-white focus-visible:ring-blue-500/50 focus-visible:border-blue-500/50 rounded-xl px-4 placeholder:text-zinc-700 transition-all"
                           placeholder="you@agency.com"
                         />
@@ -114,7 +110,6 @@ export const SignInView = () => {
                   )}
                 />
 
-                {/* Password Field */}
                 <FormField
                   control={form.control}
                   name="password"
@@ -135,6 +130,7 @@ export const SignInView = () => {
                         <Input
                           {...field}
                           type="password"
+                          autoComplete="current-password"
                           className="h-11 bg-zinc-950 border-zinc-800 text-white focus-visible:ring-blue-500/50 focus-visible:border-blue-500/50 rounded-xl px-4 placeholder:text-zinc-700 transition-all"
                           placeholder="••••••••"
                         />
@@ -145,7 +141,6 @@ export const SignInView = () => {
                 />
               </div>
 
-              {/* Submit Button */}
               <Button
                 disabled={login.isPending}
                 type="submit"
@@ -166,7 +161,7 @@ export const SignInView = () => {
                 )}
               </Button>
             </form>
-            {/* Divider */}
+
             <div className="relative py-2">
               <div className="absolute inset-0 flex items-center">
                 <span className="w-full border-t border-zinc-800" />
@@ -178,7 +173,6 @@ export const SignInView = () => {
               </div>
             </div>
 
-            {/* OAuth Buttons */}
             <div className="grid grid-cols-2 gap-4">
               <Button
                 type="button"
@@ -225,7 +219,6 @@ export const SignInView = () => {
           </Form>
         </div>
 
-        {/* Secondary Action */}
         <p className="text-center text-sm text-zinc-500">
           New here?{" "}
           <Link
@@ -237,8 +230,7 @@ export const SignInView = () => {
         </p>
       </div>
 
-      {/* Minimalist Footer */}
-      <footer className="absolute bottom-8 flex gap-6 text-[11px] text-zinc-600 uppercase tracking-widest font-medium">
+      <footer className="relative z-10 mt-8 pb-8 flex flex-wrap justify-center gap-6 text-[11px] text-zinc-600 uppercase tracking-widest font-medium">
         <span>© {new Date().getFullYear()} ShipSpace</span>
         <span className="w-1 h-1 bg-zinc-800 rounded-full my-auto" />
         <Link href="/privacy" className="hover:text-zinc-400 transition-colors">

--- a/src/modules/auth/ui/view/sign-in-view.tsx
+++ b/src/modules/auth/ui/view/sign-in-view.tsx
@@ -19,7 +19,7 @@ import { useTRPC } from "@/trpc/client";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
-import { CommandIcon, ShieldCheckIcon } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import Image from "next/image";
 
 export const SignInView = () => {
@@ -54,139 +54,200 @@ export const SignInView = () => {
   };
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 min-h-screen">
-      {/* Left side: Form Panel */}
-      <div className="bg-white h-screen w-full overflow-y-auto flex flex-col px-8 sm:px-16 lg:px-24 xl:px-32 relative">
-        {/* Top Nav Area */}
-        <div className="flex items-center justify-between pt-12 mb-12">
-          <Button
-            asChild
-            variant="ghost"
-            className="text-sm font-medium hover:bg-neutral-100 rounded-full"
-          >
-            <Link prefetch href="/sign-up">
-              Create account
-            </Link>
-          </Button>
-        </div>
+    <div className="min-h-screen bg-[#050505] flex flex-col items-center justify-center p-6 font-sans text-white relative overflow-hidden">
+      {/* Background Glow - Cinematic Depth */}
+      <div className="absolute top-0 left-1/2 -translate-x-1/2 w-full max-w-4xl h-[400px] bg-blue-600/10 blur-[120px] pointer-events-none" />
 
-        {/* Main Form Area */}
-        <div className="flex-1 flex flex-col justify-center max-w-md w-full mx-auto pb-24">
-          <Form {...form}>
-            <form
-              onSubmit={form.handleSubmit(onSubmit)}
-              className="flex flex-col gap-6"
-            >
-              <div className="flex flex-col items-center text-center space-y-2 mb-6">
-                <Link
-                  href="/"
-                  className="mb-2 transition-transform hover:scale-105"
-                >
-                  <div className="p-1.5 rounded-md">
-                    <Image
-                      src="/shipspace.svg"
-                      alt="shipspace"
-                      width={90}
-                      height={90}
-                    />
-                  </div>
-                </Link>
-                <h1 className="text-3xl font-semibold tracking-tight text-neutral-900">
-                  Welcome back
-                </h1>
-                <p className="text-neutral-500">
-                  Enter your credentials to access your secure client portal.
-                </p>
-              </div>
-
-              <FormField
-                name="email"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="text-sm font-medium text-neutral-700">
-                      Work Email
-                    </FormLabel>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        className="h-11 bg-neutral-50 border-neutral-200 focus-visible:ring-neutral-900"
-                        placeholder="you@company.com"
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                name="password"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="text-sm font-medium text-neutral-700 flex justify-between">
-                      Password
-                      <Link
-                        href="/forgot-password"
-                        className="text-xs text-neutral-500 hover:text-neutral-900 hover:underline"
-                      >
-                        Forgot?
-                      </Link>
-                    </FormLabel>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        type="password"
-                        className="h-11 bg-neutral-50 border-neutral-200 focus-visible:ring-neutral-900"
-                        placeholder="••••••••"
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <Button
-                disabled={login.isPending}
-                type="submit"
-                className="h-11 mt-2 w-full bg-neutral-900 text-white hover:bg-neutral-800 transition-colors rounded-md font-medium"
-              >
-                {login.isPending ? "Authenticating..." : "Sign in securely"}
-              </Button>
-            </form>
-          </Form>
-        </div>
+      {/* Top Left Logo */}
+      <div className="absolute top-8 left-8 sm:left-12">
+        <Link
+          href="/"
+          className="transition-transform hover:scale-105 block opacity-80 hover:opacity-100"
+        >
+          <div className="p-1.5 rounded-md bg-white/5 border border-white/10 backdrop-blur-sm">
+            {/* Note: Added 'invert' assuming your original SVG was black for the white background */}
+            <Image
+              src="/shipspace.svg"
+              alt="ShipSpace"
+              width={24}
+              height={24}
+              className="invert"
+            />
+          </div>
+        </Link>
       </div>
 
-      {/* Right side: Trust & Branding Panel */}
-      <div className="hidden lg:flex flex-col justify-between h-screen w-full bg-neutral-900 text-white p-12 xl:p-24">
-        <div>
-          {/* Decorative Trust Badge */}
-          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-white/10 border border-white/10 text-sm font-medium mb-8">
-            <ShieldCheckIcon className="size-4 text-emerald-400" />
-            <span className="text-neutral-200">256-bit Encrypted Portal</span>
-          </div>
-        </div>
-
-        <div className="space-y-6 max-w-lg">
-          <h2 className="text-4xl font-medium leading-tight">
-            Manage your project scopes, invoices, and deliverables in one secure
-            place.
-          </h2>
-          <p className="text-neutral-400 text-lg">
-            Our dedicated client environment ensures your business assets and
-            financial data are completely isolated and protected.
+      <div className="w-full max-w-md space-y-8 relative z-10">
+        {/* Brand Header */}
+        <div className="text-center space-y-2">
+          <h1 className="text-3xl font-semibold tracking-tight text-white">
+            Welcome back to the Space.
+          </h1>
+          <p className="text-zinc-400 text-sm">
+            Your agency command center for projects and deliverables.
           </p>
         </div>
 
-        <div className="flex items-center gap-4 text-neutral-500 text-sm">
-          <span>© {new Date().getFullYear()} ShipSpace</span>
-          <span>•</span>
-          <Link href="/privacy" className="hover:text-white transition-colors">
-            Privacy Policy
-          </Link>
-          <span>•</span>
-          <Link href="/terms" className="hover:text-white transition-colors">
-            Terms of Service
-          </Link>
+        {/* Login Card */}
+        <div className="bg-zinc-900/40 border border-zinc-800/50 p-8 rounded-2xl backdrop-blur-xl shadow-2xl">
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+              <div className="space-y-4">
+                {/* Email Field */}
+                <FormField
+                  control={form.control}
+                  name="email"
+                  render={({ field }) => (
+                    <FormItem className="space-y-1.5">
+                      <FormLabel className="text-xs font-medium text-zinc-500 uppercase tracking-wider ml-1">
+                        Work Email
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          className="h-11 bg-zinc-950 border-zinc-800 text-white focus-visible:ring-blue-500/50 focus-visible:border-blue-500/50 rounded-xl px-4 placeholder:text-zinc-700 transition-all"
+                          placeholder="you@agency.com"
+                        />
+                      </FormControl>
+                      <FormMessage className="text-red-400 text-xs ml-1" />
+                    </FormItem>
+                  )}
+                />
+
+                {/* Password Field */}
+                <FormField
+                  control={form.control}
+                  name="password"
+                  render={({ field }) => (
+                    <FormItem className="space-y-1.5">
+                      <div className="flex justify-between items-center px-1">
+                        <FormLabel className="text-xs font-medium text-zinc-500 uppercase tracking-wider">
+                          Password
+                        </FormLabel>
+                        <Link
+                          href="/forgot-password"
+                          className="text-xs text-zinc-500 hover:text-white transition-colors"
+                        >
+                          Forgot?
+                        </Link>
+                      </div>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type="password"
+                          className="h-11 bg-zinc-950 border-zinc-800 text-white focus-visible:ring-blue-500/50 focus-visible:border-blue-500/50 rounded-xl px-4 placeholder:text-zinc-700 transition-all"
+                          placeholder="••••••••"
+                        />
+                      </FormControl>
+                      <FormMessage className="text-red-400 text-xs ml-1" />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              {/* Submit Button */}
+              <Button
+                disabled={login.isPending}
+                type="submit"
+                className="w-full h-11 bg-white text-black font-semibold rounded-xl hover:bg-zinc-200 active:scale-[0.98] transition-all flex items-center justify-center gap-2 group"
+              >
+                {login.isPending ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin text-zinc-500" />
+                    Authenticating...
+                  </>
+                ) : (
+                  <>
+                    Enter Portal
+                    <span className="group-hover:translate-x-0.5 transition-transform">
+                      →
+                    </span>
+                  </>
+                )}
+              </Button>
+            </form>
+            {/* Divider */}
+            <div className="relative py-2">
+              <div className="absolute inset-0 flex items-center">
+                <span className="w-full border-t border-zinc-800" />
+              </div>
+              <div className="relative flex justify-center text-xs uppercase">
+                <span className="bg-[#050505] px-2 text-zinc-500 tracking-wider">
+                  Or continue with
+                </span>
+              </div>
+            </div>
+
+            {/* OAuth Buttons */}
+            <div className="grid grid-cols-2 gap-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() =>
+                  toast.info("OAuth disabled for demo environment.")
+                }
+                className="h-11 bg-transparent border-zinc-800 text-zinc-300 hover:bg-zinc-900 hover:text-white transition-all flex items-center justify-center gap-2"
+              >
+                <svg className="size-4" viewBox="0 0 24 24">
+                  <path
+                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                    fill="#4285F4"
+                  />
+                  <path
+                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                    fill="#34A853"
+                  />
+                  <path
+                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                    fill="#FBBC05"
+                  />
+                  <path
+                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                    fill="#EA4335"
+                  />
+                </svg>
+                Google
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() =>
+                  toast.info("OAuth disabled for demo environment.")
+                }
+                className="h-11 bg-transparent border-zinc-800 text-zinc-300 hover:bg-zinc-900 hover:text-white transition-all flex items-center justify-center gap-2"
+              >
+                <svg className="size-4 fill-current" viewBox="0 0 24 24">
+                  <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+                </svg>
+                GitHub
+              </Button>
+            </div>
+          </Form>
         </div>
+
+        {/* Secondary Action */}
+        <p className="text-center text-sm text-zinc-500">
+          New here?{" "}
+          <Link
+            href="/sign-up"
+            className="text-white font-medium hover:underline decoration-zinc-500 underline-offset-4 transition-all"
+          >
+            Create an account
+          </Link>
+        </p>
       </div>
+
+      {/* Minimalist Footer */}
+      <footer className="absolute bottom-8 flex gap-6 text-[11px] text-zinc-600 uppercase tracking-widest font-medium">
+        <span>© {new Date().getFullYear()} ShipSpace</span>
+        <span className="w-1 h-1 bg-zinc-800 rounded-full my-auto" />
+        <Link href="/privacy" className="hover:text-zinc-400 transition-colors">
+          Privacy
+        </Link>
+        <Link href="/terms" className="hover:text-zinc-400 transition-colors">
+          Terms
+        </Link>
+      </footer>
     </div>
   );
 };

--- a/src/modules/auth/ui/view/sign-up-view.tsx
+++ b/src/modules/auth/ui/view/sign-up-view.tsx
@@ -59,10 +59,8 @@ export const SignUpView = () => {
 
   return (
     <div className="min-h-screen bg-[#050505] flex flex-col items-center justify-center p-6 font-sans text-white relative overflow-hidden">
-      {/* Background Glow - Cinematic Depth */}
       <div className="absolute top-0 left-1/2 -translate-x-1/2 w-full max-w-4xl h-[400px] bg-blue-600/10 blur-[120px] pointer-events-none" />
 
-      {/* Top Left Logo */}
       <div className="absolute top-8 left-8 sm:left-12">
         <Link
           href="/"
@@ -81,7 +79,6 @@ export const SignUpView = () => {
       </div>
 
       <div className="w-full max-w-md space-y-8 relative z-10 my-12">
-        {/* Brand Header */}
         <div className="text-center space-y-2">
           <h1 className="text-3xl font-semibold tracking-tight text-white">
             Initialize your Space.
@@ -91,12 +88,10 @@ export const SignUpView = () => {
           </p>
         </div>
 
-        {/* Registration Card */}
         <div className="bg-zinc-900/40 border border-zinc-800/50 p-8 rounded-2xl backdrop-blur-xl shadow-2xl">
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
               <div className="space-y-4">
-                {/* Username / Handle Field */}
                 <FormField
                   control={form.control}
                   name="username"
@@ -107,12 +102,13 @@ export const SignUpView = () => {
                       </FormLabel>
                       <FormControl>
                         <Input
+                          autoComplete="username"
                           {...field}
                           className="h-11 bg-zinc-950 border-zinc-800 text-white focus-visible:ring-blue-500/50 focus-visible:border-blue-500/50 rounded-xl px-4 placeholder:text-zinc-700 transition-all"
                           placeholder="e.g. apex-law"
                         />
                       </FormControl>
-                      {/* Dynamic Handle Preview */}
+
                       <div className="h-4 ml-1">
                         {showPreview ? (
                           <p className="text-xs text-blue-400/80 font-medium animate-in fade-in slide-in-from-top-1">
@@ -127,7 +123,6 @@ export const SignUpView = () => {
                   )}
                 />
 
-                {/* Email Field */}
                 <FormField
                   control={form.control}
                   name="email"
@@ -138,6 +133,8 @@ export const SignUpView = () => {
                       </FormLabel>
                       <FormControl>
                         <Input
+                          type="email"
+                          autoComplete="email"
                           {...field}
                           className="h-11 bg-zinc-950 border-zinc-800 text-white focus-visible:ring-blue-500/50 focus-visible:border-blue-500/50 rounded-xl px-4 placeholder:text-zinc-700 transition-all"
                           placeholder="you@agency.com"
@@ -148,7 +145,6 @@ export const SignUpView = () => {
                   )}
                 />
 
-                {/* Password Field */}
                 <FormField
                   control={form.control}
                   name="password"
@@ -159,6 +155,7 @@ export const SignUpView = () => {
                       </FormLabel>
                       <FormControl>
                         <Input
+                          autoComplete="new-password"
                           {...field}
                           type="password"
                           className="h-11 bg-zinc-950 border-zinc-800 text-white focus-visible:ring-blue-500/50 focus-visible:border-blue-500/50 rounded-xl px-4 placeholder:text-zinc-700 transition-all"
@@ -171,7 +168,6 @@ export const SignUpView = () => {
                 />
               </div>
 
-              {/* Submit Button */}
               <Button
                 disabled={register.isPending}
                 type="submit"
@@ -192,7 +188,6 @@ export const SignUpView = () => {
                 )}
               </Button>
 
-              {/* Divider for OAuth Demo */}
               <div className="relative py-2">
                 <div className="absolute inset-0 flex items-center">
                   <span className="w-full border-t border-zinc-800" />
@@ -204,7 +199,6 @@ export const SignUpView = () => {
                 </div>
               </div>
 
-              {/* OAuth Buttons (Demo) */}
               <div className="grid grid-cols-2 gap-4">
                 <Button
                   type="button"
@@ -252,7 +246,6 @@ export const SignUpView = () => {
           </Form>
         </div>
 
-        {/* Secondary Action */}
         <p className="text-center text-sm text-zinc-500">
           Already have an account?{" "}
           <Link
@@ -264,7 +257,6 @@ export const SignUpView = () => {
         </p>
       </div>
 
-      {/* Minimalist Footer */}
       <footer className="absolute bottom-8 flex gap-6 text-[11px] text-zinc-600 uppercase tracking-widest font-medium">
         <span>© {new Date().getFullYear()} ShipSpace</span>
         <span className="w-1 h-1 bg-zinc-800 rounded-full my-auto" />

--- a/src/modules/auth/ui/view/sign-up-view.tsx
+++ b/src/modules/auth/ui/view/sign-up-view.tsx
@@ -7,7 +7,6 @@ import { registerSchema } from "../../schemas";
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -20,13 +19,7 @@ import { useTRPC } from "@/trpc/client";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
-import {
-  CommandIcon,
-  ShieldCheckIcon,
-  CreditCardIcon,
-  FileLock2Icon,
-  LayoutDashboardIcon,
-} from "lucide-react";
+import { Loader2 } from "lucide-react";
 import Image from "next/image";
 
 export const SignUpView = () => {
@@ -65,202 +58,223 @@ export const SignUpView = () => {
   const showPreview = username && !usernameErrors;
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 min-h-screen">
-      {/* Left side: Form Panel */}
-      <div className="bg-white h-screen w-full overflow-y-auto flex flex-col px-8 sm:px-16 lg:px-24 xl:px-32 relative">
-        {/* Top Nav Area */}
-        <div className="flex items-center justify-between pt-12 mb-12">
-          <Button
-            asChild
-            variant="ghost"
-            className="text-sm font-medium hover:bg-neutral-100 rounded-full"
-          >
-            <Link prefetch href="/sign-in">
-              Log in instead
-            </Link>
-          </Button>
+    <div className="min-h-screen bg-[#050505] flex flex-col items-center justify-center p-6 font-sans text-white relative overflow-hidden">
+      {/* Background Glow - Cinematic Depth */}
+      <div className="absolute top-0 left-1/2 -translate-x-1/2 w-full max-w-4xl h-[400px] bg-blue-600/10 blur-[120px] pointer-events-none" />
+
+      {/* Top Left Logo */}
+      <div className="absolute top-8 left-8 sm:left-12">
+        <Link
+          href="/"
+          className="transition-transform hover:scale-105 block opacity-80 hover:opacity-100"
+        >
+          <div className="p-1.5 rounded-md bg-white/5 border border-white/10 backdrop-blur-sm">
+            <Image
+              src="/shipspace.svg"
+              alt="ShipSpace"
+              width={24}
+              height={24}
+              className="invert"
+            />
+          </div>
+        </Link>
+      </div>
+
+      <div className="w-full max-w-md space-y-8 relative z-10 my-12">
+        {/* Brand Header */}
+        <div className="text-center space-y-2">
+          <h1 className="text-3xl font-semibold tracking-tight text-white">
+            Initialize your Space.
+          </h1>
+          <p className="text-zinc-400 text-sm">
+            Set up your agency profile to access deliverables and invoices.
+          </p>
         </div>
 
-        {/* Main Form Area */}
-        <div className="flex-1 flex flex-col justify-center max-w-md w-full mx-auto pb-24">
+        {/* Registration Card */}
+        <div className="bg-zinc-900/40 border border-zinc-800/50 p-8 rounded-2xl backdrop-blur-xl shadow-2xl">
           <Form {...form}>
-            <form
-              onSubmit={form.handleSubmit(onSubmit)}
-              className="flex flex-col gap-6"
-            >
-              <div className="flex flex-col items-center text-center space-y-2 mb-6">
-                <Link
-                  href="/"
-                  className="mb-2 transition-transform hover:scale-105"
-                >
-                  <div className="p-1.5 rounded-md">
-                    <Image
-                      src="/shipspace.svg"
-                      alt="shipspace"
-                      width={90}
-                      height={90}
-                    />
-                  </div>
-                </Link>
-                <h1 className="text-3xl font-semibold tracking-tight text-neutral-900">
-                  Create client account
-                </h1>
-                <p className="text-neutral-500">
-                  Set up your secure profile to access your project deliverables
-                  and invoices.
-                </p>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+              <div className="space-y-4">
+                {/* Username / Handle Field */}
+                <FormField
+                  control={form.control}
+                  name="username"
+                  render={({ field }) => (
+                    <FormItem className="space-y-1.5">
+                      <FormLabel className="text-xs font-medium text-zinc-500 uppercase tracking-wider ml-1">
+                        Company / Client Handle
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          className="h-11 bg-zinc-950 border-zinc-800 text-white focus-visible:ring-blue-500/50 focus-visible:border-blue-500/50 rounded-xl px-4 placeholder:text-zinc-700 transition-all"
+                          placeholder="e.g. apex-law"
+                        />
+                      </FormControl>
+                      {/* Dynamic Handle Preview */}
+                      <div className="h-4 ml-1">
+                        {showPreview ? (
+                          <p className="text-xs text-blue-400/80 font-medium animate-in fade-in slide-in-from-top-1">
+                            Your workspace:{" "}
+                            <span className="text-blue-400">@{username}</span>
+                          </p>
+                        ) : (
+                          <FormMessage className="text-red-400 text-xs" />
+                        )}
+                      </div>
+                    </FormItem>
+                  )}
+                />
+
+                {/* Email Field */}
+                <FormField
+                  control={form.control}
+                  name="email"
+                  render={({ field }) => (
+                    <FormItem className="space-y-1.5">
+                      <FormLabel className="text-xs font-medium text-zinc-500 uppercase tracking-wider ml-1">
+                        Work Email
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          className="h-11 bg-zinc-950 border-zinc-800 text-white focus-visible:ring-blue-500/50 focus-visible:border-blue-500/50 rounded-xl px-4 placeholder:text-zinc-700 transition-all"
+                          placeholder="you@agency.com"
+                        />
+                      </FormControl>
+                      <FormMessage className="text-red-400 text-xs ml-1" />
+                    </FormItem>
+                  )}
+                />
+
+                {/* Password Field */}
+                <FormField
+                  control={form.control}
+                  name="password"
+                  render={({ field }) => (
+                    <FormItem className="space-y-1.5">
+                      <FormLabel className="text-xs font-medium text-zinc-500 uppercase tracking-wider ml-1">
+                        Password
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type="password"
+                          className="h-11 bg-zinc-950 border-zinc-800 text-white focus-visible:ring-blue-500/50 focus-visible:border-blue-500/50 rounded-xl px-4 placeholder:text-zinc-700 transition-all"
+                          placeholder="••••••••"
+                        />
+                      </FormControl>
+                      <FormMessage className="text-red-400 text-xs ml-1" />
+                    </FormItem>
+                  )}
+                />
               </div>
 
-              <FormField
-                name="username"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="text-sm font-medium text-neutral-700">
-                      Company / Client Handle
-                    </FormLabel>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        className="h-11 bg-neutral-50 border-neutral-200 focus-visible:ring-neutral-900"
-                        placeholder="e.g. apex-law"
-                      />
-                    </FormControl>
-                    {showPreview && (
-                      <FormDescription className="text-xs text-neutral-500">
-                        Your secure workspace will be referenced as{" "}
-                        <strong>@{username}</strong>
-                      </FormDescription>
-                    )}
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                name="email"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="text-sm font-medium text-neutral-700">
-                      Work Email
-                    </FormLabel>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        className="h-11 bg-neutral-50 border-neutral-200 focus-visible:ring-neutral-900"
-                        placeholder="you@company.com"
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                name="password"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="text-sm font-medium text-neutral-700">
-                      Password
-                    </FormLabel>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        type="password"
-                        className="h-11 bg-neutral-50 border-neutral-200 focus-visible:ring-neutral-900"
-                        placeholder="••••••••"
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+              {/* Submit Button */}
               <Button
                 disabled={register.isPending}
                 type="submit"
-                className="h-11 mt-2 w-full bg-neutral-900 text-white hover:bg-neutral-800 transition-colors rounded-md font-medium"
+                className="w-full h-11 bg-white text-black font-semibold rounded-xl hover:bg-zinc-200 active:scale-[0.98] transition-all flex items-center justify-center gap-2 group"
               >
-                {register.isPending
-                  ? "Creating Account..."
-                  : "Create secure account"}
+                {register.isPending ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin text-zinc-500" />
+                    Creating Account...
+                  </>
+                ) : (
+                  <>
+                    Create Account
+                    <span className="group-hover:translate-x-0.5 transition-transform">
+                      →
+                    </span>
+                  </>
+                )}
               </Button>
+
+              {/* Divider for OAuth Demo */}
+              <div className="relative py-2">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t border-zinc-800" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase">
+                  <span className="bg-zinc-900/40 px-2 text-zinc-500 tracking-wider">
+                    Or continue with
+                  </span>
+                </div>
+              </div>
+
+              {/* OAuth Buttons (Demo) */}
+              <div className="grid grid-cols-2 gap-4">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() =>
+                    toast.info("OAuth disabled for demo environment.")
+                  }
+                  className="h-11 bg-transparent border-zinc-800 text-zinc-300 hover:bg-zinc-900 hover:text-white transition-all flex items-center justify-center gap-2"
+                >
+                  <svg className="size-4" viewBox="0 0 24 24">
+                    <path
+                      d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                      fill="#4285F4"
+                    />
+                    <path
+                      d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                      fill="#34A853"
+                    />
+                    <path
+                      d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                      fill="#FBBC05"
+                    />
+                    <path
+                      d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                      fill="#EA4335"
+                    />
+                  </svg>
+                  Google
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() =>
+                    toast.info("OAuth disabled for demo environment.")
+                  }
+                  className="h-11 bg-transparent border-zinc-800 text-zinc-300 hover:bg-zinc-900 hover:text-white transition-all flex items-center justify-center gap-2"
+                >
+                  <svg className="size-4 fill-current" viewBox="0 0 24 24">
+                    <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+                  </svg>
+                  GitHub
+                </Button>
+              </div>
             </form>
           </Form>
         </div>
+
+        {/* Secondary Action */}
+        <p className="text-center text-sm text-zinc-500">
+          Already have an account?{" "}
+          <Link
+            href="/sign-in"
+            className="text-white font-medium hover:underline decoration-zinc-500 underline-offset-4 transition-all"
+          >
+            Log in instead
+          </Link>
+        </p>
       </div>
 
-      {/* Right side: Trust & Feature Panel */}
-      <div className="hidden lg:flex flex-col justify-between h-screen w-full bg-neutral-900 text-white p-12 xl:p-24 border-l border-neutral-800">
-        <div>
-          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/20 text-sm font-medium mb-12 text-emerald-400">
-            <ShieldCheckIcon className="size-4" />
-            <span>Enterprise-Grade Security</span>
-          </div>
-
-          <h2 className="text-3xl xl:text-4xl font-medium leading-tight mb-12 max-w-lg">
-            Everything you need to manage your agency partnership.
-          </h2>
-
-          {/* Feature List */}
-          <div className="space-y-8 max-w-md">
-            <div className="flex gap-4 items-center">
-              <div className="shrink-0 mt-1 py-5 bg-white/10 p-2.5 rounded-lg border border-white/5">
-                <CreditCardIcon className="size-5  text-neutral-300" />
-              </div>
-              <div>
-                <h3 className="font-semibold text-lg mb-1">Secure Payments</h3>
-                <p className="text-neutral-400 leading-relaxed">
-                  Approve and pay project invoices instantly via our encrypted
-                  Stripe integration.
-                </p>
-              </div>
-            </div>
-
-            <div className="flex gap-4 items-center">
-              <div className="shrink-0 mt-1 py-5 bg-white/10 p-2.5 rounded-lg border border-white/5">
-                <FileLock2Icon className="size-5 text-neutral-300" />
-              </div>
-              <div>
-                <h3 className="font-semibold text-lg mb-1">
-                  Encrypted Deliverables
-                </h3>
-                <p className="text-neutral-400 leading-relaxed">
-                  Access your source code, design files, and final assets the
-                  second your invoice is settled.
-                </p>
-              </div>
-            </div>
-
-            <div className="flex gap-4 items-center">
-              <div className="shrink-0 mt-1 py-5 bg-white/10 p-2.5 rounded-lg border border-white/5">
-                <LayoutDashboardIcon className="size-5 text-neutral-300" />
-              </div>
-              <div>
-                <h3 className="font-semibold text-lg mb-1">Client Dashboard</h3>
-                <p className="text-neutral-400 leading-relaxed">
-                  Track project scopes, review past retainers, and manage your
-                  account in one central hub.
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-4 text-neutral-500 text-sm">
-          <span>© {new Date().getFullYear()} ShipSpace</span>
-          <span>•</span>
-          <Link
-            href="/privacy"
-            className="hover:text-neutral-300 transition-colors"
-          >
-            Privacy Policy
-          </Link>
-          <span>•</span>
-          <Link
-            href="/terms"
-            className="hover:text-neutral-300 transition-colors"
-          >
-            Terms of Service
-          </Link>
-        </div>
-      </div>
+      {/* Minimalist Footer */}
+      <footer className="absolute bottom-8 flex gap-6 text-[11px] text-zinc-600 uppercase tracking-widest font-medium">
+        <span>© {new Date().getFullYear()} ShipSpace</span>
+        <span className="w-1 h-1 bg-zinc-800 rounded-full my-auto" />
+        <Link href="/privacy" className="hover:text-zinc-400 transition-colors">
+          Privacy
+        </Link>
+        <Link href="/terms" className="hover:text-zinc-400 transition-colors">
+          Terms
+        </Link>
+      </footer>
     </div>
   );
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sign-in and sign-up pages redesigned to centered, dark single-card layouts with updated branding and footer.
  * Inline username/workspace preview added to the sign-up form.
  * Loading states show a spinner with contextual status messages during authentication and account creation.
  * OAuth buttons for Google and GitHub added (display a demo-disabled notice when used).
* **UX**
  * Password field includes an inline “Forgot?” link; quick navigation links between sign-in and sign-up included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->